### PR TITLE
docker: copy entrypoint.sh from container WORKDIR

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN cd /usr/src/TWCManager && make docker SUDO=""
 VOLUME /etc/twcmanager
 WORKDIR /usr/src/TWCManager
 
-COPY entrypoint.sh ./entrypoint.sh
+RUN cp contrib/docker/entrypoint.sh ./entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["/usr/bin/python3","-m","TWCManager"]
 


### PR DESCRIPTION
Eliminates external dependency on entrypoint.sh existing in the build context.

Tried to build a docker image using your Dockerfile so I can use my own github repo for testing my code changes, and it failed due to entrypoint.sh not being present in the build context. Not sure how your build environment looks like, but it may be a legacy that entrypoint.sh exists there.

As the full git repo is checked out for the build anyway, we can just copy it inside the container instead. Simplifies the build and ensures the latest entrypoint.sh is used when creating the image. Win-win.